### PR TITLE
Fix/UI improvements register forms and navbar

### DIFF
--- a/apps/web/app/(protected)/register/(member)/_components/form.tsx
+++ b/apps/web/app/(protected)/register/(member)/_components/form.tsx
@@ -155,7 +155,7 @@ function MemberRegisterForm(
       <form onSubmit={form.handleSubmit(handleSubmit)} className="flex h-fit w-full flex-col gap-14 px-4">
         <RegisterStatus />
         <div className="flex flex-col gap-6 px-3 md:px-[60px] lg:px-[100px] 2xl:px-80">
-          <div className="liquid flex w-full flex-col gap-5 rounded-[40px] p-5 lg:p-6 2xl:gap-8 2xl:px-8 2xl:py-6">
+          <div className="liquid flex w-full flex-col gap-5 rounded-[24px] p-5 lg:p-6 2xl:gap-8 2xl:px-8 2xl:py-6">
             <div className="grid grid-cols-2 gap-4 2xl:col-span-2">
               <p className="text-form-header text-white">1. ข้อมูลนักเรียน</p>
             </div>
@@ -371,7 +371,7 @@ function MemberRegisterForm(
               />
             </div>
           </div>
-          <div className="liquid flex w-full flex-col gap-5 rounded-[40px] p-4 2xl:gap-8 2xl:px-8 2xl:py-6">
+          <div className="liquid flex w-full flex-col gap-5 rounded-[24px] p-4 2xl:gap-8 2xl:px-8 2xl:py-6">
             <div className="grid grid-cols-2 gap-4 2xl:col-span-2">
               <p className="text-form-header text-white">2. ข้อมูลติดต่อ</p>
             </div>
@@ -458,7 +458,7 @@ function MemberRegisterForm(
             </div>
           </div>
 
-          <div className="liquid flex w-full flex-col gap-5 rounded-[40px] p-4 2xl:gap-8 2xl:px-8 2xl:py-6">
+          <div className="liquid flex w-full flex-col gap-5 rounded-[24px] p-4 2xl:gap-8 2xl:px-8 2xl:py-6">
             <div className="grid grid-cols-2 gap-4 2xl:col-span-2">
               <p className="text-form-header text-white">3. เอกสาร</p>
             </div>
@@ -471,7 +471,7 @@ function MemberRegisterForm(
                   <FormControl>
                     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-10">
                       <FormDescription className="text-sm lg:text-base">
-                        1. รูปถ่ายนักเรียนหน้าตรง ขนาด 1.5 นิ้ว*
+                        1. รูปถ่ายนักเรียนหน้าตรง ขนาด 1.5 นิ้ว <span className="text-pink-300">*</span>
                       </FormDescription>
                       <div>
                         <DocumentUploader
@@ -500,7 +500,8 @@ function MemberRegisterForm(
                       <FormDescription className="text-sm lg:text-base">
                         2. สำเนาบัตรประจำตัวประชาชน หรือบัตรประจำตัวสำหรับ{" "}
                         <span className="whitespace-nowrap">บุคคลที่ไม่ใช่สัญชาติไทย</span>
-                        พร้อมเซ็นสำเนาถูกต้อง <span className="whitespace-nowrap">(เฉพาะด้านหน้า)*</span>
+                        พร้อมเซ็นสำเนาถูกต้อง <span className="whitespace-nowrap">(เฉพาะด้านหน้า)</span>{" "}
+                        <span className="text-pink-300">*</span>
                       </FormDescription>
                       <div>
                         <DocumentUploader
@@ -527,7 +528,8 @@ function MemberRegisterForm(
                   <FormControl>
                     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-10">
                       <FormDescription className="text-sm lg:text-base">
-                        3. สำเนา ปพ.7 (ระเบียนแสดงผลการเรียน) ฉบับจริง*
+                        3. สำเนา ปพ.7 (ระเบียนแสดงผลการเรียน) ฉบับจริง{" "}
+                        <span className="text-pink-300">*</span>
                       </FormDescription>
                       <div>
                         <DocumentUploader

--- a/apps/web/app/(protected)/register/_components/document_uploader.tsx
+++ b/apps/web/app/(protected)/register/_components/document_uploader.tsx
@@ -82,7 +82,7 @@ function DocumentUploader({
 
   return (
     <div className="space-y-4">
-      <p className="text-body-3 block text-center text-white md:hidden">
+      <p className="block text-center text-xs text-white md:hidden">
         อัปโหลดเอกสารไม่เกิน {formatBytes(maxSize)} (รูปภาพและ PDF เท่านั้น)
       </p>
       {/* Upload Area */}
@@ -118,7 +118,7 @@ function DocumentUploader({
       </div>
 
       {/* Helper Text */}
-      <p className="text-body-3 hidden text-left text-white lg:block">
+      <p className="hidden text-left text-xs text-white lg:block">
         อัปโหลดเอกสารไม่เกิน {formatBytes(maxSize)} (รูปภาพและ PDF เท่านั้น)
       </p>
 

--- a/apps/web/app/(protected)/register/_components/skeleton.tsx
+++ b/apps/web/app/(protected)/register/_components/skeleton.tsx
@@ -2,7 +2,7 @@ import { Spinner } from "@workspace/ui/components/spinner"
 
 function RegisterFormSkeleton() {
   return (
-    <div className="liquid grid h-[40rem] w-full grid-cols-1 flex-col gap-5 rounded-[40px] p-4 px-3 md:px-[60px] lg:px-[100px] 2xl:gap-8 2xl:px-80 2xl:py-6">
+    <div className="liquid grid h-[40rem] w-full grid-cols-1 flex-col gap-5 rounded-[24px] p-4 px-3 md:px-[60px] lg:px-[100px] 2xl:gap-8 2xl:px-80 2xl:py-6">
       <Spinner className="size-20" />
     </div>
   )

--- a/apps/web/app/(protected)/register/adviser/_components/form.tsx
+++ b/apps/web/app/(protected)/register/adviser/_components/form.tsx
@@ -125,7 +125,7 @@ function AdviserRegisterForm(props: FormProps<AdviserRegisterSchemaType>) {
       <form onSubmit={form.handleSubmit(onSubmit)} className="flex h-fit w-full flex-col gap-14 px-4">
         <RegisterStatus />
         <div className="flex flex-col gap-6 px-3 md:px-[60px] lg:px-[100px] 2xl:px-80">
-          <div className="liquid flex w-full flex-col gap-5 rounded-[40px] p-5 lg:p-6 2xl:gap-8 2xl:px-8 2xl:py-6">
+          <div className="liquid flex w-full flex-col gap-5 rounded-[24px] p-5 lg:p-6 2xl:gap-8 2xl:px-8 2xl:py-6">
             <div className="flex flex-col gap-6">
               <div className="col-span-2 grid grid-cols-2 gap-4">
                 <p className="text-form-header col-span-2 w-full text-white">1. ข้อมูลอาจารย์</p>
@@ -345,7 +345,7 @@ function AdviserRegisterForm(props: FormProps<AdviserRegisterSchemaType>) {
             </div>
           </div>
 
-          <div className="liquid flex w-full flex-col gap-5 rounded-[40px] p-4 2xl:gap-8 2xl:px-8 2xl:py-6">
+          <div className="liquid flex w-full flex-col gap-5 rounded-[24px] p-4 2xl:gap-8 2xl:px-8 2xl:py-6">
             <div className="grid grid-cols-2 gap-4 2xl:col-span-2">
               <p className="text-form-header text-white">2. ข้อมูลติดต่อ</p>
             </div>
@@ -355,7 +355,7 @@ function AdviserRegisterForm(props: FormProps<AdviserRegisterSchemaType>) {
                 control={form.control}
                 name="email"
                 render={({ field }) => (
-                  <FormItem className="col-span-2 lg:col-span-1">
+                  <FormItem className="col-span-1 md:col-span-2 lg:col-span-1">
                     <FormLabel>
                       อีเมล <span className="align-super text-pink-300">*</span>
                     </FormLabel>
@@ -366,42 +366,40 @@ function AdviserRegisterForm(props: FormProps<AdviserRegisterSchemaType>) {
                   </FormItem>
                 )}
               />
-              <div className="col-span-2 grid grid-cols-2 gap-4">
-                <FormField
-                  control={form.control}
-                  name="phone_number"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>
-                        เบอร์โทรศัพท์ <span className="align-super text-pink-300">*</span>
-                      </FormLabel>
-                      <FormControl>
-                        <Input placeholder="0812345678" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="line_id"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>
-                        Line ID <span className="invisible align-super text-pink-300">*</span>
-                      </FormLabel>
-                      <FormControl>
-                        <Input placeholder="ID LINE" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
+              <FormField
+                control={form.control}
+                name="phone_number"
+                render={({ field }) => (
+                  <FormItem className="col-span-1 md:col-span-1 lg:col-span-1">
+                    <FormLabel>
+                      เบอร์โทรศัพท์ <span className="align-super text-pink-300">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder="0812345678" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="line_id"
+                render={({ field }) => (
+                  <FormItem className="col-span-1 md:col-span-1 lg:col-span-1">
+                    <FormLabel>
+                      Line ID <span className="invisible align-super text-pink-300">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder="ID LINE" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </div>
           </div>
 
-          <div className="liquid flex w-full flex-col gap-5 rounded-[40px] p-4 2xl:gap-8 2xl:px-8 2xl:py-6">
+          <div className="liquid flex w-full flex-col gap-5 rounded-[24px] p-4 2xl:gap-8 2xl:px-8 2xl:py-6">
             <div className="grid grid-cols-2 gap-4 2xl:col-span-2">
               <p className="text-form-header text-white">3. เอกสาร</p>
             </div>
@@ -416,7 +414,8 @@ function AdviserRegisterForm(props: FormProps<AdviserRegisterSchemaType>) {
                       <FormDescription className="text-sm lg:text-base">
                         1. สำเนาบัตรประจำตัวประชาชน หรือบัตรประจำตัวสำหรับ{" "}
                         <span className="whitespace-nowrap">บุคคลที่ไม่ใช่สัญชาติไทย</span>
-                        พร้อมเซ็นสำเนาถูกต้อง <span className="whitespace-nowrap">(เฉพาะด้านหน้า)*</span>
+                        พร้อมเซ็นสำเนาถูกต้อง <span className="whitespace-nowrap">(เฉพาะด้านหน้า)</span>{" "}
+                        <span className="text-pink-300">*</span>
                       </FormDescription>
                       <div>
                         <DocumentUploader
@@ -445,7 +444,8 @@ function AdviserRegisterForm(props: FormProps<AdviserRegisterSchemaType>) {
                       <FormDescription className="text-sm lg:text-base">
                         2. เอกสารแสดงสถานภาพการเป็นอาจารย์ประจำ ในสถานศึกษา เช่น บัตรประจำตัวอาจารย์
                         บัตรข้าราชการครู{" "}
-                        <span className="whitespace-nowrap">หรือหนังสือรับรองจากสถานศึกษา*</span>
+                        <span className="whitespace-nowrap">หรือหนังสือรับรองจากสถานศึกษา</span>{" "}
+                        <span className="text-pink-300">*</span>
                       </FormDescription>
                       <div>
                         <DocumentUploader

--- a/apps/web/app/(protected)/register/team/_components/form.tsx
+++ b/apps/web/app/(protected)/register/team/_components/form.tsx
@@ -74,7 +74,7 @@ function TeamRegisterForm(props: FormProps<TeamRegisterSchemaType>) {
       <form onSubmit={form.handleSubmit(onSubmit)} className="flex h-fit w-full flex-col gap-14">
         <RegisterStatus />
         <div className="flex flex-col gap-6 px-3 md:px-[60px] lg:px-[100px] 2xl:px-80">
-          <div className="liquid grid w-full gap-5 rounded-[40px] p-5 lg:grid-rows-[auto_1fr] lg:p-6 2xl:grid-cols-[auto_1fr] 2xl:gap-8 2xl:px-8 2xl:py-6">
+          <div className="liquid grid w-full gap-5 rounded-[24px] p-5 lg:grid-rows-[auto_1fr] lg:p-6 2xl:grid-cols-[auto_1fr] 2xl:gap-8 2xl:px-8 2xl:py-6">
             <div className="grid grid-cols-2 gap-4 2xl:col-span-2">
               <p className="text-form-header text-white">1. ข้อมูลทีม</p>
             </div>
@@ -83,7 +83,7 @@ function TeamRegisterForm(props: FormProps<TeamRegisterSchemaType>) {
                 control={form.control}
                 name="team_image"
                 render={({ field }) => (
-                  <FormItem>
+                  <FormItem className="flex items-center justify-center">
                     <FormControl>
                       <AvatarUploader
                         value={field.value}

--- a/apps/web/app/(protected)/teams/requirement.tsx
+++ b/apps/web/app/(protected)/teams/requirement.tsx
@@ -28,11 +28,11 @@ export default function Requirement() {
           <div className="flex flex-col items-center gap-6 md:items-start">
             <h3 className="text-[1.125rem] font-medium md:text-[1.5rem] 2xl:text-[1.75rem]">สำหรับอาจารย์</h3>
             <ol className="flex list-decimal flex-col gap-3 pl-6 md:gap-5">
-              <li className="text-[1rem] font-light md:text-[1.125rem] lg:text-[1.25rem] lg:font-normal 2xl:text-[1.375rem]">
+              <li className="break-words text-[1rem] font-light md:text-[1.125rem] lg:text-[1.25rem] lg:font-normal 2xl:text-[1.375rem]">
                 สำเนาบัตรประจำตัวประชาชน หรือบัตรประจำตัวสำหรับ บุคคลที่ไม่ใช่สัญชาติไทย พร้อมเซ็นสำเนาถูกต้อง
                 (เฉพาะด้านหน้า)
               </li>
-              <li className="text-[1rem] font-light md:text-[1.125rem] lg:text-[1.25rem] lg:font-normal 2xl:text-[1.375rem]">
+              <li className="break-words text-[1rem] font-light md:text-[1.125rem] lg:text-[1.25rem] lg:font-normal 2xl:text-[1.375rem]">
                 เอกสารแสดงสถานภาพการเป็นอาจารย์ประจำ ในสถานศึกษา เช่น บัตรประจำตัวอาจารย์ บัตรข้าราชการครู
                 หรือหนังสือรับรองจากสถานศึกษา
               </li>
@@ -52,14 +52,14 @@ export default function Requirement() {
               สำหรับผู้เข้าแข่งขัน
             </h3>
             <ol className="flex list-decimal flex-col gap-3 pl-6 md:gap-5">
-              <li className="text-[1rem] font-light md:text-[1.125rem] lg:text-[1.25rem] lg:font-normal 2xl:text-[1.375rem]">
+              <li className="break-words text-[1rem] font-light md:text-[1.125rem] lg:text-[1.25rem] lg:font-normal 2xl:text-[1.375rem]">
                 รูปถ่ายนักเรียนหน้าตรง ขนาด 1.5 นิ้ว
               </li>
-              <li className="text-[1rem] font-light md:text-[1.125rem] lg:text-[1.25rem] lg:font-normal 2xl:text-[1.375rem]">
+              <li className="break-words text-[1rem] font-light md:text-[1.125rem] lg:text-[1.25rem] lg:font-normal 2xl:text-[1.375rem]">
                 สำเนาบัตรประจำตัวประชาชน หรือบัตรประจำตัวสำหรับ บุคคลที่ไม่ใช่สัญชาติไทย พร้อมเซ็นสำเนาถูกต้อง
                 (เฉพาะด้านหน้า)
               </li>
-              <li className="text-[1rem] font-light md:text-[1.125rem] lg:text-[1.25rem] lg:font-normal 2xl:text-[1.375rem]">
+              <li className="break-words text-[1rem] font-light md:text-[1.125rem] lg:text-[1.25rem] lg:font-normal 2xl:text-[1.375rem]">
                 สำเนา ปพ.7 (ระเบียนแสดงผลการเรียน) ฉบับจริง
               </li>
             </ol>

--- a/apps/web/app/_components/application/index.tsx
+++ b/apps/web/app/_components/application/index.tsx
@@ -19,11 +19,13 @@ function Requirement({ title, items, imgSrc }: RequirementProps) {
         className="lg:size-65 mx-auto size-40 2xl:size-[378px]"
       />
 
-      <div className="relative z-10 min-h-[265px] w-full lg:min-h-[269px] 2xl:min-h-[374px]">
-        <div className="liquid absolute inset-x-0 top-[30px] z-10 mx-auto flex !h-fit !min-h-[235px] w-full max-w-[643px] flex-col items-center rounded-[24px] border border-white/10 px-4 pb-6 pt-8 lg:h-[303px] lg:rounded-[40px] lg:px-8 lg:pt-7 2xl:top-[50px] 2xl:h-[326px] 2xl:pt-14">
+      <div className="relative z-10 min-h-[265px] w-full lg:min-h-[320px] 2xl:min-h-[420px]">
+        <div className="liquid absolute inset-x-0 top-[30px] z-10 mx-auto flex !h-fit !min-h-[235px] w-full max-w-[643px] flex-col items-center rounded-[24px] border border-white/10 px-4 pb-6 pt-8 lg:h-[354px] lg:rounded-[40px] lg:px-8 lg:pt-7 2xl:top-[50px] 2xl:h-[372px] 2xl:pt-14">
           <ul className="text-body-2 m-0 mx-auto flex h-full flex-1 list-outside list-disc flex-col pl-6">
             {items.map((item, i) => (
-              <li key={i}>{item}</li>
+              <li key={i} className="break-words">
+                {item}
+              </li>
             ))}
           </ul>
         </div>

--- a/apps/web/app/_components/navbar/cta.tsx
+++ b/apps/web/app/_components/navbar/cta.tsx
@@ -13,8 +13,8 @@ const Landing = ({ isMobile }: { isMobile?: boolean }) => {
     )
   }
   return (
-    <Link href="/sign-in">
-      <button className="text-button-2 hidden h-[52px] cursor-pointer rounded-full bg-[linear-gradient(0deg,rgba(38,38,38,0.002),rgba(38,38,38,0.002)),radial-gradient(78.68%_99.36%_at_50%_0%,rgba(255,135,237,0.5)_0%,rgba(255,135,237,0)_100%),radial-gradient(79.19%_100%_at_50.05%_100%,#9f83dc_0%,rgba(159,131,220,0)_100%),linear-gradient(106.52deg,rgba(255,204,247,0.09)_-2.48%,rgba(159,131,220,0.09)_29.08%)] px-4 py-0 text-white shadow-[0px_0px_20px_rgba(0,0,0,0.25),inset_-1px_-1px_30px_rgba(255,204,247,0.6)] lg:block 2xl:h-[70px] 2xl:px-10 2xl:py-2.5">
+    <Link href="/sign-in" className="2xl:h-full">
+      <button className="hidden cursor-pointer items-center justify-center gap-4 rounded-full bg-gradient-to-r from-purple-400/50 to-pink-300/50 px-6 py-2 text-base shadow-xl shadow-black/25 lg:flex lg:gap-6 lg:px-8 lg:py-2.5 lg:text-lg 2xl:h-full 2xl:self-stretch 2xl:px-10 2xl:text-lg">
         ลงทะเบียน
       </button>
     </Link>

--- a/apps/web/app/_components/navbar/index.tsx
+++ b/apps/web/app/_components/navbar/index.tsx
@@ -80,7 +80,7 @@ export function Navbar({ links, CTAId, sections }: NavbarProps) {
   return (
     <div className="z-100 sticky top-0 w-full p-9 px-[24px] lg:px-[60px] 2xl:px-[160px]">
       <GlassCard className="flex items-center justify-between rounded-full pl-3 pr-5 backdrop-blur-md lg:pr-3">
-        <div className="flex w-[142px] items-center justify-center pt-1 lg:w-[100px] 2xl:w-[180px]">
+        <div className="flex w-[142px] items-center justify-center pt-1 lg:w-[120px] 2xl:w-[180px]">
           <NavLink href={"/"}>
             <Image
               style={{ width: "100%", height: "auto", objectFit: "cover" }}
@@ -91,13 +91,13 @@ export function Navbar({ links, CTAId, sections }: NavbarProps) {
             />
           </NavLink>
         </div>
-        <div className="hidden items-center lg:flex 2xl:justify-between 2xl:gap-2.5">
+        <div className="hidden items-center lg:flex lg:gap-2 2xl:justify-between 2xl:gap-2.5">
           {links.map((item, i) => {
             if (item.type === "normal" && !item.mobileOnly) {
               return (
                 <NavLink
                   key={item.label}
-                  className={`rounded-full px-4 py-4 text-white 2xl:px-6 ${isActive(item.href.replace("#", "")) ? "text-nav-1-selected liquid" : "text-nav-2"}`}
+                  className={`rounded-full px-3 py-3 text-white lg:px-3 2xl:px-6 ${isActive(item.href.replace("#", "")) ? "text-nav-1-selected liquid" : "text-nav-2"}`}
                   href={item.href}>
                   {item.label}
                 </NavLink>

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -131,7 +131,7 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="form-message"
       id={formMessageId}
-      className={cn("text-lg text-[#EA4335]", className)}
+      className={cn("text-sm text-[#EA4335]", className)}
       {...props}>
       {body}
     </p>


### PR DESCRIPTION
this is a cherry pick of #135 into main

fix: improve UI across register forms, navbar, and document cards

- Fix mobile layout for phone and line ID fields
- Reduce border radius from 40px to 24px for register containers
- Adjust upload instruction text size and form descriptions
- Add spacing and pink color for required field asterisks
- Fix navbar layout issues on iPad screens
- Resize register button for better mobile experience
- Fix document card text overflow issues
- Reduce form error message size
- Center team logo in registration form